### PR TITLE
Fixes issue 10: increase contrast of site name in header.

### DIFF
--- a/server/main/static/main/common.css
+++ b/server/main/static/main/common.css
@@ -1241,6 +1241,11 @@ body > .navbar {
     /* reset; otherwise text on navbar looks offset vs links */
     line-height: 1;
 }
+
+.navbar-default .navbar-text {
+    color: #727272;
+}
+
 .navbar-text.edd-nav-title {
     font-weight: bold;
     font-size: 18px;


### PR DESCRIPTION
This PR addresses the pa11y response:

```
code: WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail
context: <p class="navbar-text edd-nav-title">Experiment Data Depot</p>
message: This element has insufficient contrast at this conformance level. Expected a contrast ratio of at least 4.5:1, but text in this element has a contrast ratio of 4.22:1. Recommendation:  change text colour to #727272.
selector: html > body > nav > div > div:nth-child(2) > ul:nth-child(1) > li:nth-child(1) > p
```

Background information:
[https://webaim.org/articles/contrast/](https://webaim.org/articles/contrast/)