### PR TITLE
Fixes issue 11: increase contrast of main navbar text.

### DIFF
--- a/server/main/static/main/common.css
+++ b/server/main/static/main/common.css
@@ -1242,7 +1242,8 @@ body > .navbar {
     line-height: 1;
 }
 
-.navbar-default .navbar-text {
+.navbar-default .navbar-text,
+.navbar-default .navbar-nav > li > a {
     color: #727272;
 }
 


### PR DESCRIPTION
The PR addresses the pa11y response:

```
code:  WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail
context:  <a href="https://sites.google.com/lbl.gov/esedataautomation/data-acquisition-storage/experiment-data-depot-edd?authuser=0">Tutorials...</a>
message:  This element has insufficient contrast at this conformance level. Expected a contrast ratio of at least 4.5:1, but text in this element has a contrast ratio of 4.22:1. Recommendation:  change text colour to #727272.
selector:  html > body > header > div > div:nth-child(2) > nav > ul > li:nth-child(1) > a
```