### PR TITLE
Fixes issue 16: increase footer text contrast.

### DIFF
--- a/server/main/static/main/common.css
+++ b/server/main/static/main/common.css
@@ -254,7 +254,7 @@ div.errorMessage > a.close {
 /* Footer area */
 .footer-text {
     border-top: 1px solid #ccc;
-    color: #ccc;
+    color: #767676;
     font-size: 0.85em;
     margin-top: 20px;
     padding: 20px;


### PR DESCRIPTION
The PR addresses the pa11y response: 

```
code:  WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail
context:  <span class="footer-text-app">Experiment Data Depot 2....</span>
message:  This element has insufficient contrast at this conformance level. Expected a contrast ratio of at least 4.5:1, but text in this element has a contrast ratio of 1.61:1. Recommendation:  change text colour to #767676.
selector:  html > body > div:nth-child(3) > span:nth-child(1)
```