### PR TITLE
Fixes issue 17: link hover and focus contrast.

### DIFF
--- a/server/main/static/main/common.css
+++ b/server/main/static/main/common.css
@@ -74,6 +74,10 @@ a {
     color: #4c81c0;
     text-decoration: none;
 }
+a:hover,
+a:focus {
+    color: #4378b7;
+}
 a.darker {
     color: #000000;
 }


### PR DESCRIPTION
The PR addresses the pa11y response:

```
code:  WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail
context:  <a href="/utilities/">Utilities</a>
message:  This element has insufficient contrast at this conformance level. Expected a contrast ratio of at least 4.5:1, but text in this element has a contrast ratio of 4.03:1. Recommendation:  change text colour to #4378b7.
selector:  html > body > div:nth-child(3) > span:nth-child(2) > a
```