### PR TITLE
Remove autofocus from study search box.

### DIFF
--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -446,7 +446,7 @@ class DataGridSpecStudies extends DataGridSpecBase implements DGPageDataSource {
         $("#hStudyMod").css("border-right", "1px solid lightgrey");
         // Create a single widget for showing disabled Studies
         const array: DataGridHeaderWidget[] = [
-            new DGStudiesSearchWidget(dataGrid, this, "Search Studies", 40, true),
+            new DGStudiesSearchWidget(dataGrid, this, "Search Studies", 40, false),
             new DGPagingWidget(dataGrid, this, this),
         ];
         return array;


### PR DESCRIPTION
Grabbing focus prevents the page from being read by JAWs.

![search studies](https://user-images.githubusercontent.com/1245800/158691725-fe80bdec-a6b2-4a9d-8d56-75ff81e66143.png)
