### PR TITLE
Fixes issue 38: use relative h2 sizing.

### DIFF
--- a/server/main/static/main/common.css
+++ b/server/main/static/main/common.css
@@ -1432,5 +1432,5 @@ summary.pageDivider {
     transition: 0.1s ease-in;
 }
 h2 {
-    font-size: 2.143em;
+    font-size: 2.143rem;
 }

--- a/server/main/static/main/common.css
+++ b/server/main/static/main/common.css
@@ -58,7 +58,7 @@ fieldset {
 html {
     color: #000000;
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-    font-size: 14px;
+    font-size: calc(14 / 16em);
     height: 100%;
 }
 body {

--- a/server/main/static/main/common.css
+++ b/server/main/static/main/common.css
@@ -1431,3 +1431,6 @@ summary.pageDivider {
     top: 0;
     transition: 0.1s ease-in;
 }
+h2 {
+    font-size: 2.143em;
+}


### PR DESCRIPTION
This addresses an issue with `<h2>` elements taking absolute font-sizes.

Context:
[C12](https://www.w3.org/TR/2008/WD-WCAG20-TECHS-20081103/C12) 
[C13](https://www.w3.org/TR/2008/WD-WCAG20-TECHS-20081103/C13) 
[C14](https://www.w3.org/TR/2008/WD-WCAG20-TECHS-20081103/C14)