### PR TITLE
Fixes issue 18: no h1 on page.

### DIFF
--- a/server/edd/campaign/templates/edd/campaign/detail.html
+++ b/server/edd/campaign/templates/edd/campaign/detail.html
@@ -41,6 +41,7 @@
       </form>
     </div>
   {% endif %}
+  <h2>{{ campaign.name }}</h2>
   <p>{{ campaign.description }}</p>
   {% if is_paginated %}
     <hr/>

--- a/server/edd/campaign/templates/edd/campaign/detail.html
+++ b/server/edd/campaign/templates/edd/campaign/detail.html
@@ -41,7 +41,6 @@
       </form>
     </div>
   {% endif %}
-  <h1>{{ campaign.name }}</h1>
   <p>{{ campaign.description }}</p>
   {% if is_paginated %}
     <hr/>

--- a/server/edd/describe/templates/edd/describe/help.html
+++ b/server/edd/describe/templates/edd/describe/help.html
@@ -47,7 +47,7 @@
 </div>
 
 <a name="experiment_description"></a>
-<h2>What is an Experiment Description file?</h1>
+<h2>What is an Experiment Description file?</h2>
 
 <p>An experiment description file is a simple Excel file that allows you to quickly enter the
     experimental conditions for your Study. EDD needs to know what the experimental

--- a/server/edd/describe/templates/edd/describe/help.html
+++ b/server/edd/describe/templates/edd/describe/help.html
@@ -47,7 +47,7 @@
 </div>
 
 <a name="experiment_description"></a>
-<h1>What is an Experiment Description file?</h1>
+<h2>What is an Experiment Description file?</h1>
 
 <p>An experiment description file is a simple Excel file that allows you to quickly enter the
     experimental conditions for your Study. EDD needs to know what the experimental

--- a/server/edd/load/templates/edd/load/load.html
+++ b/server/edd/load/templates/edd/load/load.html
@@ -328,7 +328,7 @@
           tweak them. In most cases, you can verify correctness by inspecting a plot of the data
           that will appear below. You can also go back and edit your data in Step 2 without losing
           your settings here.</p>
-        <h1>Importing subsets of the file content:</h1>
+        <h2>Importing subsets of the file content:</h2>
         <ul>
           <li>Check/uncheck boxes above and to the left of the table to enable or disable the
             entire row or column. Disabled rows/columns will be omitted when your data is
@@ -612,12 +612,12 @@
       first!</div>
   </div>
   <div class="sectionContent step5Subsection off" id="reviewErrorsSection">
-    <h1>Errors</h1>
+    <h2>Errors</h2>
     <p>Import is disabled until all errors have been resolved.</p>
     <div id="reviewErrorsContentDiv"></div>
   </div>
   <div class="sectionContent step5Subsection off" id="reviewWarningsSection">
-    <h1>Warnings</h1>
+    <h2>Warnings</h2>
     <p>You must resolve or acknowledge all warnings before import is allowed.</p>
     <div id="reviewWarningsContentDiv"></div>
   </div>

--- a/server/main/static/main/common.css
+++ b/server/main/static/main/common.css
@@ -1431,3 +1431,7 @@ summary.pageDivider {
     top: 0;
     transition: 0.1s ease-in;
 }
+
+h1.edd-nav-title {
+    padding: 0.2em;
+}

--- a/server/main/templates/500.default.html
+++ b/server/main/templates/500.default.html
@@ -19,14 +19,13 @@
         <div class="collapse navbar-collapse">
           <ul class="nav navbar-nav navbar-left">
             <li>
-              <p class="navbar-text edd-nav-title">Page Unavailable</p>
+              <h1 class="navbar-text edd-nav-title">Page Unavailable</h1>
             </li>
           </ul>
         </div>
       </div>
     </nav>
     <div class="content">
-      <h1>Page Unavailable</h1>
       <p>EDD has encountered an error and cannot show this page. The site administrators have been
         notified of the problem, please check back later.</p>
     </div>

--- a/server/main/templates/account/logout.html
+++ b/server/main/templates/account/logout.html
@@ -2,11 +2,13 @@
 {% load i18n %}
 {% load static %}
 
-
 {% block head_title %}
-  {% trans "Sign Out" %} &mdash; {{ block.super }}
+{% trans "Sign Out" %} &mdash; {{ block.super }}
 {% endblock %}
 
+{% block body_title %}
+  {% trans 'Sign Out' %}
+{% endblock body_title %}
 
 {% block js_css %}
   {{ block.super }}
@@ -17,7 +19,6 @@
 {% block content %}
   <form class="login_form" method="post" action="{% url 'account_logout' %}">
     {% csrf_token %}
-    <h1>{% trans "Sign Out" %}</h1>
     <p>{% trans 'Are you sure you want to sign out?' %}</p>
     {% if redirect_field_value %}
       <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}"/>

--- a/server/main/templates/account/verification_sent.html
+++ b/server/main/templates/account/verification_sent.html
@@ -5,13 +5,16 @@
 
 {% block head_title %}{% trans "Verify Your E-mail Address" %} &mdash; {{ block.super }}{% endblock %}
 
+{% block body_title %}
+    {% trans "Verification Sent" %}
+{% endblock body_title %}
+
 {% block js_css %}
     <link rel="stylesheet" type="text/css" href="{% static 'main/login.css' %}" />
 {% endblock js_css %}
 
 {% block content %}
     <div class="login_form">
-        <h1>{% trans "Verify Your E-mail Address" %}</h1>
         <p>
             {% blocktrans %}
             We have sent an e-mail to you for verification. Follow the link provided to finalize

--- a/server/main/templates/edd_base.html
+++ b/server/main/templates/edd_base.html
@@ -51,11 +51,11 @@
       <div class="collapse navbar-collapse">
         <ul class="nav navbar-nav navbar-left">
           <li>
-            <p class="navbar-text edd-nav-title">
+            <h1 class="navbar-text edd-nav-title">
               {% block body_title %}
               {% trans 'Experiment Data Depot' context 'Top of page title' %}
               {% endblock body_title %}
-            </p>
+            </h1>
           </li>
           <li>
             <p class="navbar-text">{% env_label %}</p>


### PR DESCRIPTION
This addresses an issue where `<h1>` elements were missing from pages, and the page title was not wrapped in an `<h1>`. In cases where `<h1>`s already existed, I moved their content to the header `<h1>` and removed the tag elsewhere, leaving a single `<h1>` on every page in the same location everywhere.

Context:
[G141](https://www.w3.org/TR/WCAG20-TECHS/G141.html)