### PR TITLE
Add show password link.

### DIFF
--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -124,6 +124,7 @@ The following configuration options are specific to EDD and may be overridden in
 
 -   `EDD_ALLOW_SIGNUP` -- boolean flag; if True, self-registration of accounts
     is enabled.
+-   `EDD_ALLOW_SHOW_PASSWORD` -- boolean flag; if True, show "Show password" button
 -   `EDD_DEPLOYMENT_ENVIRONMENT` -- string value, changes background color and
     adds a visual environment label to assist in telling apart testing vs
     production instances. A None value will result in no visual changes added

--- a/server/edd/branding/templatetags/branding.py
+++ b/server/edd/branding/templatetags/branding.py
@@ -109,3 +109,8 @@ def login_welcome(context):
     except Exception:
         # with no branding, show no welcome message
         return ""
+
+
+@register.simple_tag()
+def show_password_button():
+    return getattr(settings, "EDD_ALLOW_SHOW_PASSWORD", False)

--- a/server/edd/settings/edd.py
+++ b/server/edd/settings/edd.py
@@ -25,6 +25,8 @@ EDD_DEPLOYMENT_ENVIRONMENT = env("EDD_DEPLOYMENT_ENVIRONMENT", default="TEST")
 # EDD_ALLOW_SIGNUP: False disables signup; callable will be called with a
 #   request object; string type will attempt to import and call module
 EDD_ALLOW_SIGNUP = True
+# EDD_ALLOW_SHOW_PASSWORD: False removes the "Show password" button
+EDD_ALLOW_SHOW_PASSWORD = env("EDD_ALLOW_SHOW_PASSWORD", default=False)
 # EDD_ONLY_SUPERUSER_CREATE: True disables all study creation by non-superusers.
 EDD_ONLY_SUPERUSER_CREATE = False
 # EDD_DEFAULT_STUDY_READ_GROUPS: list of groups that automatically get READ

--- a/server/main/templates/account/login.html
+++ b/server/main/templates/account/login.html
@@ -18,6 +18,7 @@
   {% if socialaccount_providers %}
   {% providers_media_js %}
   {% endif %}
+  <script type="text/javascript" src="{% static 'dist/Login.js' %}"></script>
 {% endblock js_css %}
 
 {% block status %}
@@ -76,11 +77,58 @@
       <legend>{% trans 'Login with EDD Account' %}</legend>
       <div>
         {{ form.login.label_tag }}
-        <input type="text" name="login" autocomplete="username" maxlength="150" required aria-invalid="false" id="id_login">
+        <input
+          type="text"
+          name="login"
+          autocomplete="username"
+          maxlength="150"
+          required="required"
+          aria-invalid="false"
+          id="id_login"
+        />
       </div>
-      <div>
+      <div class="passwordContainer">
         {{ form.password.label_tag }}
-        <input type="password" name="password" autocomplete="current-password" required aria-invalid="false" id="id_password">
+        <input
+          type="password"
+          name="password"
+          autocomplete="current-password"
+          required="required"
+          aria-invalid="false"
+          id="id_password"
+        />
+        {% show_password_button as show_password %}
+        {% if show_password %}
+          <a href="#"
+            class="showPassword"
+            id="show-password"
+            aria-controls="id_password"
+            role="switch"
+            aria-pressed="false"
+            aria-label="{% translate 'Show password' %}"
+          >{% translate "Show" context "password toggle" %}</a>
+          <span id="show-password-show" aria-hidden="true" class="off">
+            {% translate "Show" context "password toggle" %}
+          </span>
+          <span id="show-password-hide" aria-hidden="true" class="off">
+            {% translate "Hide" context "password toggle" %}
+          </span>
+          <span id="show-password-show-label" aria-hidden="true" class="off">
+            {% translate "Show password" %}
+          </span>
+          <span id="show-password-hide-label" aria-hidden="true" class="off">
+            {% translate "Hide password" %}
+          </span>
+          <span id="show-password-shown-sr" aria-hidden="true" class="off">
+            {% translate "Password shown." %}
+          </span>
+          <span id="show-password-hidden-sr" aria-hidden="true" class="off">
+            {% translate "Password hidden." %}
+          </span>
+          <p aria-live="polite" id="password-text" class="sr-only">
+            {% translate "Password hidden." %}
+          </p>
+        {% endif %}
         <div>
           <a class="forgotPassword" href="{% url 'account_reset_password' %}">
             {% trans 'Forgot password?' %}

--- a/typescript/src/Login.ts
+++ b/typescript/src/Login.ts
@@ -1,0 +1,28 @@
+"use strict";
+
+import "jquery";
+
+$(() => {
+    $(document).on("click", "#show-password", (e) => {
+        e.preventDefault();
+        const target = $(e.currentTarget);
+        const hidingPassword = target.attr("aria-pressed") === "true";
+        if (hidingPassword) {
+            const show = $("#show-password-show").text().trim();
+            const showLabel = $("#show-password-show-label").text().trim();
+            const hiddenSR = $("#show-password-hidden-sr").text().trim();
+            target.text(show).attr("aria-label", showLabel);
+            $("#id_password").attr("type", "password");
+            $("#password-text").text(hiddenSR);
+        } else {
+            const hide = $("#show-password-hide").text().trim();
+            const hideLabel = $("#show-password-hide-label").text().trim();
+            const shownSR = $("#show-password-shown-sr").text().trim();
+            target.text(hide).attr("aria-label", hideLabel);
+            $("#id_password").attr("type", "text");
+            $("#password-text").text(shownSR);
+        }
+        target.attr("aria-pressed", hidingPassword ? "false" : "true");
+        return false;
+    });
+});

--- a/typescript/webpack.config.js
+++ b/typescript/webpack.config.js
@@ -47,6 +47,7 @@ module.exports = {
             "react-stepzilla.css",
             path.resolve(__dirname, "./src/LoadWizard.tsx"),
         ],
+        "Login": path.resolve(__dirname, "./src/Login.ts"),
         "Skyline_Convert": path.resolve(__dirname, "./src/Skyline_Convert.ts"),
         "StudyData": path.resolve(__dirname, "./src/Study-Data.ts"),
         "StudyLines": path.resolve(__dirname, "./src/Study-Lines.ts"),


### PR DESCRIPTION
This change adds a link beside login page's password field to allow users to toggle whether it is shown. Justification for requiring such a link is outlined [here](https://incl.ca/show-hide-password-accessibility-and-password-hints-tutorial/), as are the techniques I adopted to make this change.