### PR TITLE
Fixes several a11y issues with the login form.

### DIFF
--- a/server/main/templates/account/login.html
+++ b/server/main/templates/account/login.html
@@ -56,11 +56,11 @@
       <legend>{% trans 'Login with EDD Account' %}</legend>
       <div>
         {{ form.login.label_tag }}
-        {{ form.login }}
+        <input type="text" name="login" autocomplete="username" maxlength="150" required aria-invalid="false" id="id_login">
       </div>
       <div>
         {{ form.password.label_tag }}
-        {{ form.password }}
+        <input type="password" name="password" autocomplete="current-password" required aria-invalid="false" id="id_password">
         <div>
           <a class="forgotPassword" href="{% url 'account_reset_password' %}">
             {% trans 'Forgot password?' %}
@@ -68,7 +68,7 @@
         </div>
       </div>
 
-      <button id="id_click" type="submit">{% trans 'Login' %}</button>
+      <button class="btn btn-primary" id="id_click" type="submit">{% trans 'Login' %}</button>
       <input
           type="hidden"
           name="{{ redirect_field_name }}"


### PR DESCRIPTION
This PR replaces the default username and password with these changes:

Uses standard `btn{-*}` classes on the submit button. Unstyled buttons lack sufficient 3:1 contrast to the background, as per [1.4.11](https://www.w3.org/TR/WCAG21/#non-text-contrast). Note that these classes remain valid in Bootstrap > 3.

Removes placeholders on the login and password fields, which were causing screen-readers to identify them twice. Labels are sufficient identification, and generally placeholders should indicate examples of valid input, if anything.

Adds `aria-invalid=false` to both fields, which prevents screen-readers from announcing required fields as invalid before they have been interacted with.