### PR TITLE
Signup uses bootstrap styles and more accessible markup.

### DIFF
--- a/server/edd/account.py
+++ b/server/edd/account.py
@@ -2,8 +2,10 @@ import logging
 
 from allauth import account, exceptions, socialaccount
 from allauth.account.forms import ResetPasswordForm as BaseResetPasswordForm
+from allauth.account.forms import SignupForm as BaseSignupForm
 from django.conf import settings
 from django.contrib import auth, messages, sites
+from django.contrib.auth.password_validation import password_validators_help_text_html
 from django.db.models import Q
 from django.shortcuts import redirect
 from django.urls import reverse
@@ -181,3 +183,17 @@ class ResetPasswordForm(BaseResetPasswordForm):
             self.users = account.utils.filter_users_by_email(email)
         # base class .save() call generates reset token and sends email to self.users
         return super().save(request, **kwargs)
+
+
+class SignupForm(BaseSignupForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["password1"].help_text = password_validators_help_text_html()
+        self.fields["password1"].widget.attrs["aria-describedby"] = "id_password1_help"
+        self.fields["password2"].label = _("Re-enter password")
+        for visible in self.visible_fields():
+            # class required to be styled by Bootstrap
+            visible.field.widget.attrs["class"] = "form-control"
+            # prevent fields from being announced as invalid when form is first displayed
+            visible.field.widget.attrs["aria-invalid"] = "false"
+            del visible.field.widget.attrs["placeholder"]

--- a/server/edd/settings/auth.py
+++ b/server/edd/settings/auth.py
@@ -10,8 +10,9 @@ ACCOUNT_DEFAULT_HTTP_PROTOCOL = "https"
 ACCOUNT_EMAIL_REQUIRED = True
 ACCOUNT_EMAIL_VERIFICATION = "mandatory"
 ACCOUNT_FORMS = {
+    "signup": "edd.account.SignupForm",
     # use our override of password reset form behavior
-    "reset_password": "edd.account.ResetPasswordForm"
+    "reset_password": "edd.account.ResetPasswordForm",
 }
 ACCOUNT_USERNAME_REQUIRED = False
 SOCIALACCOUNT_ADAPTER = "edd.account.EDDSocialAccountAdapter"

--- a/server/main/static/main/common.css
+++ b/server/main/static/main/common.css
@@ -1456,3 +1456,16 @@ summary.pageDivider {
 h1.edd-nav-title {
     padding: 0.2em;
 }
+
+.centered-form {
+    margin: 100px auto;
+    padding: 20px 30px;
+    width: 510px;
+}
+.centered-form label {
+    margin-bottom: 5px;
+}
+
+.centered-form p {
+    margin: 0 0 1rem 0;
+}

--- a/server/main/templates/account/signup.html
+++ b/server/main/templates/account/signup.html
@@ -5,21 +5,32 @@
 {% block head_title %}{% translate "Signup" %} &mdash; {{ block.super }}{% endblock %}
 
 {% block content %}
-    <form class="signup" id="signup_form login_form" method="post"
+    <form class="signup centered-form" id="signup_form" method="post"
             action="{% url 'account_signup' %}">
         {% csrf_token %}
-        <fieldset>
-            <legend>{% translate "Sign Up" %}</legend>
-            <p>
-                {% blocktranslate %}
-                Already have an account? Then please <a href="{{ login_url }}">sign in</a>.
-                {% endblocktranslate %}
-            </p>
-            {{ form.as_p }}
-            {% if redirect_field_value %}
-            <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
-            {% endif %}
-            <button type="submit">{% translate "Sign Up" %} &raquo;</button>
-        </fieldset>
+        <h1>{% translate "Sign Up" %}</h1>
+        <p>
+            {% blocktranslate %}
+            Already have an account? Then please <a href="{{ login_url }}">sign in</a>.
+            {% endblocktranslate %}
+        </p>
+
+        {% for field in form.visible_fields %}
+            <div class="form-group{% if field.errors %} has-error{% endif %}">
+                {{ field.label_tag }}
+                {{ field }}
+                <div id="id_{{field.name}}_help" class="help-block">
+                    {{ f.errors }}
+                    {% if field.help_text %}
+                        <p>{{ field.help_text }}</p>
+                    {% endif %}
+                </div>
+            </div>
+        {% endfor %}
+
+        {% if redirect_field_value %}
+        <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
+        {% endif %}
+        <button type="submit" class="btn btn-primary">{% translate "Sign Up" %} <span role="presentation">&raquo;</span></button>
     </form>
 {% endblock content %}

--- a/typescript/modules/Forms.ts
+++ b/typescript/modules/Forms.ts
@@ -623,12 +623,21 @@ export class FormMetadataManager {
     }
 }
 
+export function initializeInputsWithErrors(inputs: JQuery): void {
+    inputs.each((index, input) => {
+        input.setAttribute("aria-invalid", "true");
+    });
+}
+
 export function handleChangeRequiredInput(event: JQueryEventObject): void {
     const input = event.target as HTMLInputElement;
+    input.setAttribute("aria-invalid", "false");
     input.setCustomValidity("");
     input.checkValidity();
 }
 
+// Override the default HTML validation messages so that the field name
+// and additional context is announced to users of assistive technology.
 export function handleInvalidRequiredInput(event: JQueryEventObject): void {
     const $input = $(event.target);
     const input = event.target as HTMLInputElement;
@@ -646,6 +655,6 @@ export function handleInvalidRequiredInput(event: JQueryEventObject): void {
             // fall back to assumed English with label
             input.setCustomValidity(`${labelText} required.`);
         }
-        input.reportValidity();
+        input.setAttribute("aria-invalid", "true");
     }
 }

--- a/typescript/src/Common.ts
+++ b/typescript/src/Common.ts
@@ -12,6 +12,7 @@ import * as Notification from "../modules/Notification";
 import {
     handleChangeRequiredInput,
     handleInvalidRequiredInput,
+    initializeInputsWithErrors,
 } from "../modules/Forms";
 
 import "../modules/Styles";
@@ -85,6 +86,8 @@ function prepareIt(): void {
     $(document).on("blur input", "input[required]", handleChangeRequiredInput);
     // invalid event must be directly attached to elements
     $("input[required]").on("invalid", handleInvalidRequiredInput);
+    // Set correct aria-invalid value for fields with server-set errors
+    initializeInputsWithErrors($(".has-error input"));
 }
 
 // use JQuery ready event shortcut to call prepareIt when page is ready


### PR DESCRIPTION
This PR makes a few interrelated improvements to the signup page:

* The form fields now use the default Bootstrap styles
* The surrounding `fieldset` was removed so that "sign up" wasn't repeated before the name of every form field. On such a small form, there isn't a need to group inputs together in this way.
* A new custom Form class was defined to modify some of the default `allauth` behavior.
* A bit of JS was added to toggle the value of "aria-invalid" as a part of providing custom validation error messages. This will help assistive tech users get feedback that the fields contain invalid values.

This PR addresses issues 149, 152, 153, 154, 157, 167, 171, and 180.
![Screen Shot 2022-04-04 at 10 55 26 AM](https://user-images.githubusercontent.com/3331/161592147-6c54ef8c-77c7-4800-aa0a-a6adb37ec19e.png)
![Screen Shot 2022-04-04 at 10 55 30 AM](https://user-images.githubusercontent.com/3331/161592149-7d1800b1-fbbc-4ceb-a3e0-7b79ab9ed276.png)
![Screen Shot 2022-04-04 at 10 55 50 AM](https://user-images.githubusercontent.com/3331/161592151-f7ec17e3-1276-4d22-91e8-bee39bcdb301.png)

