### PR TITLE
Truss a11y normalize h1 in main

### DIFF
--- a/server/main/static/main/common.css
+++ b/server/main/static/main/common.css
@@ -787,7 +787,6 @@ div.editable-field {
     vertical-align: top;
 }
 div.editable-field.inactive {
-    padding-right: 27px;
     padding-bottom: 2px;
     padding-left: 4px;
     padding-top: 2px;
@@ -795,9 +794,14 @@ div.editable-field.inactive {
     transition: box-shadow 150ms ease-in 0ms;
     box-shadow: 0 0 0 0 transparent;
 }
+
+#editable-study-name.inactive,
+#editable-study-name.inactive input {
+    flex-grow: 0;
+}
 div.editable-field input,
 div.editable-field textarea {
-    width: 99%;
+    flex-grow: 1;
 }
 div.editable-field.inactive input,
 div.editable-field.inactive textarea {
@@ -929,10 +933,6 @@ td.editable-field span.icon.icon-accept {
 td.editable-field span.icon.icon-cancel {
     background-position: 4px 3px;
     background-image: url(images/edit-cancel.png);
-}
-
-.editableStudyName {
-    font-size: 150%;
 }
 
 a.close {
@@ -1455,4 +1455,10 @@ summary.pageDivider {
 
 h1.edd-nav-title {
     padding: 0.2em;
+}
+
+.sectionActions h1 {
+    display: flex;
+    align-items: center;
+    margin: 0;
 }

--- a/server/main/static/main/login.css
+++ b/server/main/static/main/login.css
@@ -1,4 +1,4 @@
-.login_form {
+main.account {
     margin: 100px auto;
     padding: 20px 30px;
     width: 400px;

--- a/server/main/templates/account/base.html
+++ b/server/main/templates/account/base.html
@@ -1,6 +1,7 @@
 {% extends "edd_base.html" %}
 {% load static %}
 
+{% block main_class %}account{% endblock %}
 
 {% block js_css %}
   {{ block.super }}

--- a/server/main/templates/account/login.html
+++ b/server/main/templates/account/login.html
@@ -6,11 +6,16 @@
 {% load static %}
 
 {% block head_title %}
-  {{ block.super }}
   {% if form.non_field_errors|length %}
-    {% translate '- Login Error' %}
+    {{ block.super }} &mdash; {% translate "Login Error" context "page title" %}
+  {% else %}
+    {{ block.super }} &mdash; {% translate "Login" context "page title" %}
   {% endif %}
 {% endblock head_title %}
+
+{% block body_title %}
+  {% translate 'Login' %}
+{% endblock body_title %}
 
 {% block js_css %}
   {{ block.super }}

--- a/server/main/templates/account/logout.html
+++ b/server/main/templates/account/logout.html
@@ -6,9 +6,9 @@
 {% translate "Sign Out" %} &mdash; {{ block.super }}
 {% endblock %}
 
-{% block body_title %}
-  {% translate 'Sign Out' %}
-{% endblock body_title %}
+{% block body_title %}{% translate 'Sign Out' %}{% endblock body_title %}
+
+{% block main_class %}account{% endblock %}
 
 {% block js_css %}
   {{ block.super }}

--- a/server/main/templates/account/password_reset.html
+++ b/server/main/templates/account/password_reset.html
@@ -3,14 +3,15 @@
 {% load i18n %}
 {% load account %}
 
-{% block head_title %}{% translate "Password Reset" %} &mdash; {{ block.super }}{% endblock %}
+{% block head_title %}{{ block.super }} &mdash; {% translate "Password Reset" %}{% endblock %}
+
+{% block body_title %}{% translate "Password Reset" %}{% endblock body_title %}
 
 {% block content %}
     <form method="POST" action="{% url 'account_reset_password' %}"
             class="password_reset login_form">
         {% csrf_token %}
         <fieldset>
-            <legend>{% translate "Password Reset" %}</legend>
             {% if user.is_authenticated %}
             {% include "account/snippets/already_logged_in.html" %}
             {% endif %}

--- a/server/main/templates/account/signup.html
+++ b/server/main/templates/account/signup.html
@@ -4,12 +4,15 @@
 
 {% block head_title %}{% translate "Signup" %} &mdash; {{ block.super }}{% endblock %}
 
+{% block body_title %}{% translate "Signup" %}{% endblock body_title %}
+
+{% block main_class %}account{% endblock %}
+
 {% block content %}
     <form class="signup" id="signup_form login_form" method="post"
             action="{% url 'account_signup' %}">
         {% csrf_token %}
         <fieldset>
-            <legend>{% translate "Sign Up" %}</legend>
             <p>
                 {% blocktranslate %}
                 Already have an account? Then please <a href="{{ login_url }}">sign in</a>.

--- a/server/main/templates/edd_base.html
+++ b/server/main/templates/edd_base.html
@@ -51,11 +51,9 @@
       <div class="collapse navbar-collapse">
         <ul class="nav navbar-nav navbar-left">
           <li>
-            <h1 class="navbar-text edd-nav-title">
-              {% block body_title %}
+            <p class="navbar-text edd-nav-title">
               {% translate 'Experiment Data Depot' context 'Top of page title' %}
-              {% endblock body_title %}
-            </h1>
+            </p>
           </li>
           <li>
             <p class="navbar-text">{% env_label %}</p>
@@ -115,7 +113,7 @@
       </div>
     </div>
   </header>
-  <main id="content" class="content" tabindex="-1">
+  <main id="content" class="content {% block main_class %}{% endblock main_class %}" tabindex="-1">
     {% block status %}
       {% if messages %}
         {% csrf_token %}
@@ -131,6 +129,13 @@
         {% endfor %}
       {% endif %}
     {% endblock status %}
+    {% block default_h1 %}
+      <h1>
+        {% block body_title %}
+          {% translate 'Experiment Data Depot' context 'Main title' %}
+        {% endblock body_title %}
+      </h1>
+    {% endblock default_h1 %}
     {% block content %}
     {% endblock content %}
   </main>

--- a/server/main/templates/main/index.html
+++ b/server/main/templates/main/index.html
@@ -8,6 +8,10 @@
   <script type="text/javascript" src="{% static 'dist/index.js' %}"></script>
 {% endblock js_css %}
 
+{% block body_title %}
+  {% translate 'Studies Overview' %}
+{% endblock body_title %}
+
 
 {% block content %}
   {% if can_create %}

--- a/server/main/templates/main/study-data.html
+++ b/server/main/templates/main/study-data.html
@@ -13,6 +13,8 @@
 {% block content %}
   {{ block.super }}
 
+  <h1>{% translate study.name %}&nbsp;&mdash;&nbsp;{% translate "Data" %}</h1>
+
   <a id="settinglink" href="{{ settinglink }}" class="off"></a>
   <div class="btn-toolbar flex-row sectionActions">
     <div

--- a/server/main/templates/main/study-lines.html
+++ b/server/main/templates/main/study-lines.html
@@ -55,6 +55,7 @@
     </p>
   </div>
   {% endif %}
+  <h1>{% translate study.name %}&nbsp;&mdash;&nbsp;{% translate "Description" %}</h1>
   <div class="flex-row sectionActions">
     <div class="flex-item">
       <nav class="hidden pager-nav">

--- a/server/main/templates/main/study-overview.html
+++ b/server/main/templates/main/study-overview.html
@@ -3,7 +3,6 @@
 {% load static %}
 {% load i18n %}
 
-
 {% block js_css %}
   {{ block.super }}
   <link rel="stylesheet" type="text/css" href="{% static 'main/study-overview.css' %}" />
@@ -30,19 +29,21 @@
     <div class="sectionActions">
       <div class="flex-row">
         {% if writable %}
-        <div class="editable-field inactive editableStudyName flex-item" id="editable-study-name">
-          {{ study.name }}
-          {{ edit_study.name }}
-        </div>
+          <h1>
+            <div class="editable-field inactive editableStudyName flex-item" id="editable-study-name">
+              {% translate study.name %}
+              {{ edit_study.name }}
+            </div><span>&nbsp;&mdash;&nbsp;{% translate "Overview" %}</span>
+          </h1>
         {% url "main:load:wizard" slug=study.slug as wizard_url %}
         <a class="{% if not lines %}off{% endif %} btn btn-primary btn-large" href="{{ wizard_url}}">
             <span class="fas fa-cloud-upload-alt"></span>
             {% translate 'Import Data' %}
         </a>
         {% else %}
-        <div class="flex-item">
-          {{ study.name }}
-        </div>
+        <h1 class="flex-item">
+          {{ study.name }}&nbsp;&mdash;&nbsp;{% translate "Overview" %}
+        </h1>
         {% endif %}
       </div>
       <div class="flex-row">

--- a/server/main/templates/main/study.html
+++ b/server/main/templates/main/study.html
@@ -7,9 +7,20 @@
   {{ study.name }} &ndash; {{ block.super }}
 {% endblock head_title %}
 
+{% block nav_title %}
+  {% translate study.name %}
+{% endblock nav_title %}
+
+{% comment %}
+  removes the default h1 behavior
+{% endcomment %}
+{% block default_h1 %}
+{% endblock default_h1 %}
+
+{% block main_class %}study{% endblock main_class %}
 
 {% block body_title %}
-  {{ study.name }}
+  {% translate study.name %}
 {% endblock body_title %}
 
 


### PR DESCRIPTION
This adds `h1`s  to every page's `main` element, with the possibility for overrides. 
By default, `h1`s are placed next after any first-child alert descendants of `main`.
Using an empty `default_h1` block removes this `h1`, allowing templates to override it elsewhere.
The `body_title` block now sets the content of this `h1`, rather than updating the main nav title, which keeps the heading in the `main` element. 
The study pages set the `body_title` conditionally, and then in some cases inherit it into their custom `h1`.
The `main_class` block allows a class to be added to the main element to accomplish CSS overrides. I did this on both the account pages -- to leave the layout of the account pages unaffected -- and the study pages -- to consistently style the heading only on those pages.
Note that the study overview page's title editor is now contained within the `h1`, with " - Overview" concatenated, which lets the content of the heading stay up-to-date.