### PR TITLE
Truss a11y study tab contrast

### DIFF
--- a/server/main/static/main/common.css
+++ b/server/main/static/main/common.css
@@ -1342,24 +1342,22 @@ body > .navbar {
     margin: 0px 15px 0px 15px;
 }
 .studyNav .nav > li > a {
-    color: lightgray;
+    color: #31708f;
     position: relative;
     display: block;
     padding: 10px 15px;
-    border-bottom: 2px solid lightgray;
+    border-bottom: 1px solid #31708f;
     border-radius: 0px;
 }
 .nav {
     list-style: none;
     padding-left: 0;
 }
-.studyNav .navbar .nav > .active > a {
-    background: none;
-}
 .studyNav .nav > li > a:hover,
+.studyNav .navbar .nav > .active > a,
 .nav > li > a:focus {
-    text-decoration: none;
     background-color: rgba(0, 0, 0, 0.1);
+    text-decoration: none;
     border-bottom: 2px solid grey;
     border-radius: 0px;
     color: black;
@@ -1389,6 +1387,10 @@ body > .navbar {
     border-bottom: 2px solid grey;
     border-radius: 0px;
 }
+/* .studyNav .nav-pills > li.active > a,
+.studyNav .nav-pills > li.active > a:hover {
+    background-color: rgba(0, 0, 0, 0.1);
+} */
 
 .pageDivider {
     position: relative;

--- a/server/main/static/main/common.css
+++ b/server/main/static/main/common.css
@@ -1356,8 +1356,8 @@ body > .navbar {
 .studyNav .nav > li > a:hover,
 .studyNav .navbar .nav > .active > a,
 .nav > li > a:focus {
-    background-color: rgba(0, 0, 0, 0.1);
     text-decoration: none;
+    background-color: rgba(0, 0, 0, 0.1);
     border-bottom: 2px solid grey;
     border-radius: 0px;
     color: black;
@@ -1387,10 +1387,10 @@ body > .navbar {
     border-bottom: 2px solid grey;
     border-radius: 0px;
 }
-/* .studyNav .nav-pills > li.active > a,
+.studyNav .nav-pills > li.active > a,
 .studyNav .nav-pills > li.active > a:hover {
     background-color: rgba(0, 0, 0, 0.1);
-} */
+}
 
 .pageDivider {
     position: relative;

--- a/server/main/templates/edd_base.html
+++ b/server/main/templates/edd_base.html
@@ -24,8 +24,7 @@
   {% block js_css %}
   {% endblock js_css%}
 </head>
-{% comment %} <body style="background-color:{% env_background_color %};"> {% endcomment %}
-  <body style="background-color:white">
+<body style="background-color:{% env_background_color %};">
   {% block sr_header_alert %}
   {% endblock %}
   <a class="skip-to-content-link" href="#content">Skip to main content</a>

--- a/server/main/templates/edd_base.html
+++ b/server/main/templates/edd_base.html
@@ -24,7 +24,8 @@
   {% block js_css %}
   {% endblock js_css%}
 </head>
-<body style="background-color:{% env_background_color %};">
+{% comment %} <body style="background-color:{% env_background_color %};"> {% endcomment %}
+  <body style="background-color:white">
   {% block sr_header_alert %}
   {% endblock %}
   <a class="skip-to-content-link" href="#content">Skip to main content</a>


### PR DESCRIPTION
This uses a blue shade for the Study page nav's inactive links, which is a sufficient 4.5:1 contrast ratio. I'm using a 1px bottom border on inactive links, and a grey background on active and hovered links.