### PR TITLE
Improve accessibility of study export form

### DIFF
--- a/server/edd/export/forms.py
+++ b/server/edd/export/forms.py
@@ -254,6 +254,10 @@ assay_option = table.TableOptions(models.Assay)
 measure_option = table.TableOptions(models.Measurement)
 
 
+class AccessibleCheckboxSelectMultiple(forms.CheckboxSelectMultiple):
+    template_name = "edd/export/accessible_checkbox_select.html"
+
+
 class ExportOptionForm(forms.Form):
     """
     Form used for changing options on exports.
@@ -281,35 +285,35 @@ class ExportOptionForm(forms.Form):
         coerce=study_option.coerce,
         label=_("Study fields to include"),
         required=False,
-        widget=forms.CheckboxSelectMultiple,
+        widget=AccessibleCheckboxSelectMultiple,
     )
     line_meta = forms.TypedMultipleChoiceField(
         choices=line_option.choices,
         coerce=line_option.coerce,
         label=_("Line fields to include"),
         required=False,
-        widget=forms.CheckboxSelectMultiple,
+        widget=AccessibleCheckboxSelectMultiple,
     )
     protocol_meta = forms.TypedMultipleChoiceField(
         choices=protocol_option.choices,
         coerce=protocol_option.coerce,
         label=_("Protocol fields to include"),
         required=False,
-        widget=forms.CheckboxSelectMultiple,
+        widget=AccessibleCheckboxSelectMultiple,
     )
     assay_meta = forms.TypedMultipleChoiceField(
         choices=assay_option.choices,
         coerce=assay_option.coerce,
         label=_("Assay fields to include"),
         required=False,
-        widget=forms.CheckboxSelectMultiple,
+        widget=AccessibleCheckboxSelectMultiple,
     )
     measure_meta = forms.TypedMultipleChoiceField(
         choices=measure_option.choices,
         coerce=measure_option.coerce,
         label=_("Measurement fields to include"),
         required=False,
-        widget=forms.CheckboxSelectMultiple,
+        widget=AccessibleCheckboxSelectMultiple,
     )
 
     def __init__(self, *args, **kwargs):

--- a/server/edd/export/templates/edd/export/accessible_checkbox_select.html
+++ b/server/edd/export/templates/edd/export/accessible_checkbox_select.html
@@ -1,0 +1,19 @@
+{% with id=widget.attrs.id %}
+    <div{% if id %} id="{{ id }}"{% endif %}class="checkbox {{ widget.attrs.class }}">
+        {% for group, options, index in widget.optgroups %}
+            {% for option in options %}
+            <div>
+                <label for="{{option.attrs.id}}">
+                    {% include "django/forms/widgets/checkbox.html" with widget=option %}
+                    {{option.label}}
+                </label>
+            </div>
+            {% endfor %}
+        {% endfor %}
+        <div class="select-controls">
+            <button class="btn btn-link select-all" aria-describedby="{{id}}_legend">Select All</button>
+            <button class="btn btn-link deselect-all" aria-describedby="{{id}}_legend">Deselect All</button>
+            <div class="announcements sr-only" aria-live="assertive"></div>
+        </div>
+    </div>
+{% endwith %}

--- a/server/edd/export/templates/edd/export/export.html
+++ b/server/edd/export/templates/edd/export/export.html
@@ -2,12 +2,10 @@
 {% load static %}
 {% load i18n %}
 
-
 {% block js_css %}
   {{ block.super }}
   <script type="text/javascript" src="{% static 'dist/Export.js' %}"></script>
 {% endblock js_css %}
-
 
 {% block head_title %}
   {% blocktranslate with name=primary_study.name count count=selection.studies|length %}
@@ -17,17 +15,6 @@
   {% endblocktranslate %}
 {% endblock head_title %}
 
-
-{% block body_title %}
-  {% url 'main:detail' slug=primary_study.slug as study_url %}
-  {% blocktranslate with name=primary_study.name url=study_url count count=selection.studies|length %}
-  Data Export for <a href="{{ url }}">{{ name }}</a>
-  {% plural %}
-  Data Export for {{ count }} Studies, including <a href="{{ url }}">{{ name }}</a>
-  {% endblocktranslate %}
-{% endblock body_title %}
-
-
 {% block content %}
 <!-- Line info section -->
 {% include "edd/export/linetable.html" %}
@@ -36,10 +23,50 @@
 <form method="post" id="exportForm" action="{% url 'export:export' %}">
   {% csrf_token %}
   <div class="pageSection">
-    <div class="sectionHead">{% translate 'Choose the export layout.' %}</div>
+    <div class="sectionHead">
+      <h1>{% translate 'Choose the export layout.' %}</h1>
+    </div>
+    <p class="lead">
+      {% url 'main:detail' slug=primary_study.slug as study_url %}
+      {% blocktranslate with name=primary_study.name url=study_url count count=selection.studies|length %}
+      Data Export for <a href="{{ url }}">{{ name }}</a>
+      {% plural %}
+      Data Export for {{ count }} Studies, including <a href="{{ url }}">{{ name }}</a>
+      {% endblocktranslate %}
+    </p>
     <div class="sectionContent exportOptions">
       {{ select_form.as_p }}
-      {{ option_form.as_p }}
+
+      {% for field in option_form %}
+        {% if field.field.widget.input_type == 'checkbox' and field.field.widget.allow_multiple_selected %}
+          <div class="checkbox">
+            <fieldset>
+              <legend id="{{field.name}}_legend">
+                <h2>{{ field.label }}</h2>
+              </legend>
+              {{ field.errors }}
+              {{ field }}
+            </fieldset>
+
+          </div>
+        {% elif field.field.widget.input_type == 'checkbox' %}
+          <div class="form-group checkbox">
+            <label for="{{field.id_for_label}}">
+              {{ field }}
+              {{ field.label }}
+              {{ field.errors }}
+            </label>
+          </div>
+        {% else %}
+          <div class="form-group">
+            <label for="{{field.id_for_label}}">{{field.label}}
+              {{ field.errors }}
+              {{ field }}
+            </label>
+          </div>
+        {% endif %}
+      {% endfor %}
+
       <button
         class="btn btn-primary btn-lg"
         name="action"

--- a/server/main/static/main/common.css
+++ b/server/main/static/main/common.css
@@ -1099,6 +1099,27 @@ form.comments textarea {
     float: left;
     padding-right: 1em;
 }
+.exportOptions fieldset {
+    padding: 0.5em;
+    margin: 1rem 0 2rem;
+    border: none;
+    border-bottom: solid 1px gray;
+}
+.exportOptions legend {
+    font-weight: bold;
+    margin-left: -5px;
+}
+.exportOptions .select-controls {
+    position: absolute;
+    top: -2.8em;
+    right: 0;
+    text-align: right;
+}
+.exportOptions h2 {
+    font-size: 1em;
+    font-weight: bold;
+    margin: 0;
+}
 .exportDisplay textarea {
     width: 100%;
 }

--- a/typescript/src/Export.ts
+++ b/typescript/src/Export.ts
@@ -2,30 +2,28 @@ import "jquery";
 
 export function setUp(): void {
     // add select/deselect controls
-    $(".exportOptions > ul[id$=_meta]").each(function (i, ul) {
-        const $ul = $(ul),
-            css = { "float": "right", "padding-left": "1em" };
-        $('<a href="#">')
-            .text("Deselect All")
-            .css(css)
-            .on("click", () => {
-                $ul.find(":checkbox").prop("checked", false);
-                return false;
-            })
-            .appendTo($ul.prev("p"));
-        $('<a href="#">')
-            .text("Select All")
-            .css(css)
-            .on("click", () => {
-                $ul.find(":checkbox").prop("checked", true);
-                return false;
-            })
-            .appendTo($ul.prev("p"));
+    $(".exportOptions div[id$=_meta]").each(function (i, div) {
+        const $div = $(div);
+        const $legend = $div.closest("fieldset").find("legend");
+        const $announcements = $div.find(".announcements");
+
+        $div.find("button.select-all").on("click", (event) => {
+            event.preventDefault();
+            $div.find(":checkbox").prop("checked", true);
+            $announcements.text(`All fields selected, ${$legend.text()}`);
+        });
+
+        $div.find("button.deselect-all").on("click", (event) => {
+            event.preventDefault();
+            $div.find(":checkbox").prop("checked", false);
+            $announcements.text(`All fields deselected, ${$legend.text()}`);
+        });
     });
+
     // click handler for disclose sections
-    $(document).on("click", ".disclose .discloseLink", (e) => {
-        $(e.target).closest(".disclose").toggleClass("discloseHide");
-        return false;
+    $(document).on("click", ".disclose .discloseLink", (event) => {
+        event.preventDefault();
+        $(event.target).closest(".disclose").toggleClass("discloseHide");
     });
 }
 


### PR DESCRIPTION
The changes in this PR fall into a few categories:
* The addition of a heading to the page and restyling this using Bootstrap classes.
* Adjustments to how the app generated the HTML for the form. Some defaults needed to be overridden to associate the checkboxes with the groups they belonged to for assistive tech. Django 4 looks like it has moved more of its form rendering into templates, so if/when the app upgrades some of this work can probably be shared more easily across forms.
* The controls to select or deselect all checkboxes in a group are now buttons and their tab order is what a user would expect.
* When the select or deselect all buttons are activated, the result is announced to users of assistive tech so they know that something happened.

Additionally, we adjusted the display of the form for sighted users to make it easier to scan for specific checkboxes:

![image](https://user-images.githubusercontent.com/3331/162250795-ed9b1f71-eb8a-4d7d-aa2d-0e93737f1383.png)

This PR fixes issues 175, 178, 187, 190, 191, 192, 194, 195, 196, 198, and 236.