### PR TITLE
Fixes issues with Study overview page.

### DIFF
--- a/server/main/forms.py
+++ b/server/main/forms.py
@@ -435,6 +435,7 @@ class CreateStudyForm(forms.ModelForm):
         widgets = {
             "name": forms.widgets.TextInput(
                 attrs={
+                    "aria-label": _("Study Name"),
                     "aria-invalid": "false",
                     "class": "form-control",
                     "data-validation-text": _("Study Name is required."),
@@ -444,7 +445,11 @@ class CreateStudyForm(forms.ModelForm):
                 },
             ),
             "description": forms.widgets.Textarea(
-                attrs={"cols": 49, "class": "form-control"}
+                attrs={
+                    "aria-label": _("Study Description"),
+                    "cols": 49,
+                    "class": "form-control",
+                }
             ),
             "contact": UserAutocompleteWidget(),
         }
@@ -531,6 +536,7 @@ class CreateAttachmentForm(forms.ModelForm):
         labels = {"file": _(""), "description": _("Description")}
         help_texts = {"description": _(""), "file": _("")}
         widgets = {"description": forms.widgets.TextInput()}
+        attrs = {"aria-label": _("Add Attachment")}
 
     def __init__(self, *args, **kwargs):
         # removes default hard-coded suffix of colon character on all labels
@@ -553,8 +559,17 @@ class CreateCommentForm(forms.ModelForm):
     class Meta:
         model = Comment
         fields = ("body",)
-        labels = {"body": _("")}
         help_texts = {"body": _("")}
+        widgets = {
+            "body": forms.Textarea(
+                attrs={
+                    "rows": 10,
+                    "cols": 40,
+                    "class": "form-control",
+                    "aria-label": _("Body"),
+                }
+            ),
+        }
 
     def __init__(self, *args, **kwargs):
         # removes default hard-coded suffix of colon character on all labels

--- a/server/main/static/main/common.css
+++ b/server/main/static/main/common.css
@@ -71,7 +71,7 @@ p {
 }
 /* Links */
 a {
-    color: #4c81c0;
+    color: #4378b7;
     text-decoration: none;
 }
 a:hover,
@@ -1084,6 +1084,9 @@ input[type="checkbox"].form-control {
 form.comments textarea {
     width: 50%;
 }
+form.comments .form-group textarea {
+    margin-bottom: 1em;
+}
 
 .exportOptions > p {
     clear: both;
@@ -1157,7 +1160,7 @@ div.overviewDropZone {
     background-color: #eeeeee;
     border: 1px solid #e0e0e0;
     text-align: center;
-    color: gray;
+    color: #6c6c6c;
     padding-bottom: 16px;
 }
 div.linesZone {
@@ -1455,4 +1458,8 @@ summary.pageDivider {
 
 h1.edd-nav-title {
     padding: 0.2em;
+}
+
+.attach-icon {
+    margin-right: 0.25em;
 }

--- a/server/main/static/main/study-overview.css
+++ b/server/main/static/main/study-overview.css
@@ -8,7 +8,7 @@
 
 #experimentDescDropZone > .dz-message a,
 #describeDirectionsDiv a {
-    color: grey;
+    color: #6c6c6c;
     text-decoration: underline;
 }
 
@@ -91,7 +91,7 @@ div.overviewDropZone {
 }
 
 #describeDirectionsDiv {
-    color: grey;
+    color: #767676;
     width: 200px;
 }
 
@@ -101,4 +101,9 @@ div.overviewDropZone {
 
 table.permissions {
     width: 640px;
+}
+
+.btn-danger {
+    background-color: #ce4844;
+    border-color: #ce4844;
 }

--- a/server/main/templates/main/include/attachments.html
+++ b/server/main/templates/main/include/attachments.html
@@ -7,16 +7,17 @@ TODO deleting a file may be a little too easy; should we require confirmation?
 -->
 {% endcomment %}
 <table class="table table-condensed table-striped" id="attach-table">
+  <caption class="sr-only">{% translate 'Attachments' %}</caption>
   {% if attachments %}
   <thead>
     <tr>
-      <th>{% translate 'Filename' %}</th>
-      <th>{% translate 'Description' %}</th>
-      <th class="text-right">{% translate 'Size' %}</th>
-      <th class="text-center">{% translate 'Added By' %}</th>
-      <th>{% translate 'Date Added' %}</th>
+      <th scope="col">{% translate 'Filename' %}</th>
+      <th scope="col">{% translate 'Description' %}</th>
+      <th scope="col" class="text-right">{% translate 'Size' %}</th>
+      <th scope="col" class="text-center">{% translate 'Added By' %}</th>
+      <th scope="col">{% translate 'Date Added' %}</th>
       {% if writable %}
-      <th class="text-right">{% translate 'Delete' %}</th>
+      <th scope="col" class="text-right">{% translate 'Delete' %}</th>
       {% endif %}
     </tr>
   </thead>
@@ -25,11 +26,11 @@ TODO deleting a file may be a little too easy; should we require confirmation?
     {% for a in attachments %}
     {% with slug=study.slug urlname=a.filename|urlencode %}
     {% url 'main:attachment' slug=slug file_id=a.id file_name=urlname as filelink %}
-    <tr>
-      <td class="nowrap">
-        <img class="attach-icon" src="{% static 'main/images/' %}{{ a.icon }}"/>
+    <tr role="row">
+      <td class="nowrap">{% spaceless %}
+        <img class="attach-icon" alt="attach-icon" aria-hidden="true" src="{% static 'main/images/' %}{{ a.icon }}"/>
         <a href="{{ filelink }}">{{ a.filename }}</a>
-      </td>
+      {% endspaceless %}</td>
       <td>{{ a.description }}</td>
       <td class="text-right">{{ a.file_size|filesizeformat }}</td>
       <td class="text-center">{{ a.user_initials }}</td>

--- a/server/main/templates/main/study-overview.html
+++ b/server/main/templates/main/study-overview.html
@@ -273,8 +273,8 @@
     <div class="sectionActions">
       <form method="POST" class="comments edd-form">
         {% csrf_token %}
-        {{ new_comment.as_p }}
-        <p>
+        <div class="form-group">
+          {{ new_comment.body }}
           <button
             class="btn btn-primary"
             name="action"
@@ -283,7 +283,7 @@
           >
             {% translate 'Add Comment' %}
           </button>
-        </p>
+        </div>
       </form>
     </div>
   </div>
@@ -335,7 +335,7 @@
           <input type="radio" id="permission_user" name="class" value="User" hidden/>
           <span>{% translate 'User' %}</span>
         </label>
-        <select id="user_permission_options" name="type">
+        <select id="user_permission_options" name="type" aria-label="{% translate 'User Permission Options' %}">
           <option value="{{ permission_none }}">{% translate 'None' %}</option>
           <option value="{{ permission_read }}">{% translate 'Read' %}</option>
           <option value="{{ permission_write }}">{% translate 'Write' %}</option>
@@ -347,7 +347,7 @@
           <input type="radio" id="permission_group" name="class" value="Group" hidden/>
           <span>{% translate 'Group' %}</span>
         </label>
-        <select id="group_permission_options" name="type">
+        <select id="group_permission_options" name="type" aria-label="{% translate 'Group Permission' %}">
           <option value="{{ permission_none }}">{% translate 'None' %}</option>
           <option value="{{ permission_read }}">{% translate 'Read' %}</option>
           <option value="{{ permission_write }}">{% translate 'Write' %}</option>
@@ -360,7 +360,7 @@
         <label for="permission_public">
           <span>{% translate 'Everyone' %}</span>
         </label>
-        <select name="type">
+        <select name="type" aria-label="{% translate 'Everyone Permission'>
           <option value="{{ permission_none }}">{% translate 'None' %}</option>
           <option value="{{ permission_read }}">{% translate 'Read' %}</option>
           <option value="{{ permission_write }}">{% translate 'Write' %}</option>

--- a/server/main/views/study.py
+++ b/server/main/views/study.py
@@ -325,6 +325,7 @@ class StudyOverviewView(StudyDetailBaseView):
         form = edd_forms.CreateCommentForm(request.POST, edd_object=self.get_object())
         if form.is_valid():
             form.save()
+            messages.success(request, _("Comment saved."))
             return True
         context["new_comment"] = form
         return False

--- a/typescript/modules/Forms.ts
+++ b/typescript/modules/Forms.ts
@@ -638,13 +638,13 @@ export function handleInvalidRequiredInput(event: JQueryEventObject): void {
     } else if (input.validity.valueMissing || input.validity.patternMismatch) {
         const elementValidity = $input.data("validationText");
         const id = $input.attr("id");
-        const labelText = $(`label[for=${id}]`).text();
+        const labelText = $(`label[for=${id}]`).text() || $input.attr("aria-label");
         if (elementValidity) {
             // prefer text added to element with i18n
             input.setCustomValidity(elementValidity);
         } else if (labelText) {
             // fall back to assumed English with label
-            input.setCustomValidity(`${labelText} required.`);
+            input.setCustomValidity(`The "${labelText}" field is required.`);
         }
         input.reportValidity();
     }

--- a/typescript/src/Common.ts
+++ b/typescript/src/Common.ts
@@ -82,9 +82,9 @@ function prepareIt(): void {
     });
 
     // adding handlers for required input validation
-    $(document).on("blur input", "input[required]", handleChangeRequiredInput);
+    $(document).on("blur input", "*[required]", handleChangeRequiredInput);
     // invalid event must be directly attached to elements
-    $("input[required]").on("invalid", handleInvalidRequiredInput);
+    $("*[required]").on("invalid", handleInvalidRequiredInput);
 }
 
 // use JQuery ready event shortcut to call prepareIt when page is ready


### PR DESCRIPTION
This fixes a number of issues on the Study Overview:

- Adds `aria-labels` to the name, description, add attachment, and comment body fields.
- Increases contrast levels on global `a`, export options, describe directions, and `btn-danger`.
- Improves screen reader announcements on new comment form, and permissions and attachments tables.
- Announces field label when any required element fires `invalid`.

Note that tab navigation becomes trapped in the comment `textarea` if it's invalid, but this should be fixed in @jim's commit [here](https://github.com/JBEI/edd/pull/60/files).