### PR TITLE
Fixes some issues on the New Study form page.

### DIFF
--- a/server/main/forms.py
+++ b/server/main/forms.py
@@ -428,7 +428,7 @@ class CreateStudyForm(forms.ModelForm):
         model = Study
         fields = ["name", "description", "contact"]
         labels = {
-            "name": _("Study Name"),
+            "name": _("Study Name (required)"),
             "description": _("Description"),
             "contact": _("Contact"),
         }

--- a/server/main/static/main/common.css
+++ b/server/main/static/main/common.css
@@ -1009,7 +1009,6 @@ ol.comment-list > li {
 .edd-form > p > .edd-label {
     display: inline-block;
     vertical-align: top;
-    width: 8em;
 }
 .edd-form > p > label {
     line-height: 20px; /* bare text looks too offset compared to text boxes, so tweak line-height */
@@ -1019,7 +1018,7 @@ ol.comment-list > li {
     margin-left: 1em;
 }
 .helptext {
-    color: gray;
+    color: #767676;
     display: block;
     font-size: 11px;
 }

--- a/server/main/views/study.py
+++ b/server/main/views/study.py
@@ -75,6 +75,9 @@ class StudyCreateView(generic.edit.CreateView):
         return kwargs
 
     def get_success_url(self):
+        messages.success(
+            self.request, _('Created Study "{study}".').format(study=self.object.name)
+        )
         return reverse("main:overview", kwargs={"slug": self.object.slug})
 
 

--- a/typescript/modules/MultiColumnAutocomplete.ts
+++ b/typescript/modules/MultiColumnAutocomplete.ts
@@ -99,7 +99,9 @@ export class NonValueItem {
             const result = $("<li>").data("ui-autocomplete-item", item);
             if (item instanceof NonValueItem) {
                 this._appendMessage(result, item.label);
+                this._setAriaLabel(result, item.label);
             } else {
+                const labelValues = [];
                 $.each(this.options.columns, (index, column) => {
                     let value;
                     if (column.valueField) {
@@ -114,11 +116,19 @@ export class NonValueItem {
                     if (value instanceof Array) {
                         value = value[0] || "";
                     }
+                    if (value.trim()) {
+                        labelValues.push(`${column.valueField}: ${value}`);
+                    }
                     this._appendCell(result, column, value);
                 });
+                this._setAriaLabel(result, labelValues.join(", "));
             }
             result.appendTo(ul);
             return result;
+        },
+        "_setAriaLabel": function (row, label) {
+            row.attr("aria-label", label);
+            return row;
         },
     });
 })(jQuery);


### PR DESCRIPTION
Changes in this PR:

- Adds "(required)" to the name field's label on the New Study form.
- Removes a width restriction on that label.
- Pushes a success message to the redirect URL when a Study is created.
- Generates and applies `aria-label`s to the Contact dropdown results.