### PR TITLE
Study Description page issues.

### DIFF
--- a/server/main/static/main/common.css
+++ b/server/main/static/main/common.css
@@ -1456,3 +1456,14 @@ summary.pageDivider {
 h1.edd-nav-title {
     padding: 0.2em;
 }
+
+.description-alert {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.description-alert p {
+    padding: 0;
+    margin: 0;
+}

--- a/server/main/templates/main/study-lines.html
+++ b/server/main/templates/main/study-lines.html
@@ -24,15 +24,7 @@
 >
   {% csrf_token %}
   {% if writable %}
-  <div class="alert alert-info alert-dismissible" role="alert">
-    <button
-      aria-label="{% translate 'Close' %}"
-      class="close"
-      data-dismiss="alert"
-      type="button"
-    >
-      <span aria-hidden="true">&times;</span>
-    </button>
+  <div class="alert alert-info alert-dismissible description-alert" role="alert">
     <p>
       {% blocktranslate trimmed %}
       Drag-and-drop an Experiment Description file on the table below to add more lines.
@@ -53,6 +45,14 @@
         {% translate 'Help' %}
       </a>
     </p>
+    <button
+      aria-label="{% translate "Close 'description file help' alert" %}"
+      class="close"
+      data-dismiss="alert"
+      type="button"
+    >
+      <span aria-hidden="true">&times;</span>
+    </button>
   </div>
   {% endif %}
   <div class="flex-row sectionActions">
@@ -123,7 +123,7 @@
     <div>
       {% if writable %}
       <div class="btn-group dropup">
-        <button class="btn btn-primary needs-lines-selected" id="editButton" type="button">
+        <button class="btn btn-primary needs-lines-selected" id="editButton" type="button" aria-hidden>
           <span class="fas fa-pencil-alt"></span>
           {% translate 'Edit' %}
           <span class="badge selected-line-count"></span>
@@ -131,6 +131,7 @@
         <button
           aria-expanded="false"
           aria-haspopup="true"
+          aria-label="{% translate "Toggle 'Edit' dropdown" %}"
           class="btn btn-primary dropdown-toggle"
           data-toggle="dropdown"
           type="button"
@@ -167,13 +168,14 @@
         </ul>
       </div>
       <div class="btn-group dropup">
-        <button class="btn btn-primary addNewLineButton" type="button">
+        <button class="btn btn-primary addNewLineButton" type="button" aria-hidden>
           <span class="fas fa-plus"></span>
           {% translate 'Add Line' %}
         </button>
         <button
           aria-expanded="false"
           aria-haspopup="true"
+          aria-label="{% translate "Toggle 'Add Line' dropdown" %}"
           class="btn btn-primary dropdown-toggle"
           data-toggle="dropdown"
           type="button"


### PR DESCRIPTION
- Fixes keyboard tab order of alert. The close button had appeared first in the DOM, giving it keyboard focus before the buttons in the alert. It now comes after in the DOM order, and I corrected the styles with display: flex.
- Clarifies aria-label on close button. The aria-label now gives some context as to what is being closed.
- Improves announcements on UI elements. Since the "Edit" and "Add line" buttons are decorative, I gave them aria-hidden. I also gave their respective caret buttons a descriptive aria-label.