### PR TITLE
Improves accessibility of line graphs.

### DIFF
--- a/typescript/modules/table/Graph.ts
+++ b/typescript/modules/table/Graph.ts
@@ -415,6 +415,16 @@ export class Graph {
         return this.is_truncated;
     }
 
+    getDashArray(color: string): string {
+        // generates an almost-unique dash array based on the color
+        return parseInt(color.split("#")[1], 16)
+            .toString(4)
+            .split("")
+            .slice(0, 5)
+            .map((dash) => 6 * parseInt(dash))
+            .join(" ");
+    }
+
     /**
      * Renders a line plot from the given filtered items, grouped by a replicate key.
      * The replicate key should be one of Keys.byAssay, Keys.byLine, or Keys.byReplicate.
@@ -694,12 +704,14 @@ export class Graph {
             // get color from the first item; they should all be the same
             const first_item = values[0].item;
             const color = first_item.line.color;
+            const dasharray = this.getDashArray(color);
             // add G element for entire curve
             const curve_group = parent
                 .append("g")
                 .attr("class", "curve graphValue")
                 .attr("fill", "none")
                 .attr("stroke", color)
+                .style("stroke-dasharray", dasharray)
                 .on("mousemove", this.tooltipOver(first_item))
                 .on("mouseout", this.tooltipOut());
             // add PATH element for plot path


### PR DESCRIPTION
WCAG 2.0 [requires that color not be the only means of conveying information](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-without-color.html). For line graphs, using the `stroke-dasharray` attribute or style can help with this.

Here, I'm generating a dash array from the color converted to base 4, and then scaling the first five digits by a factor of 6. This strikes a balance between uniqueness -- much of the time dash arrays will be unique among colors -- and recognizability -- not having a dash array so long that the pattern is difficult to grok.

Another approach would be to iterate over a fixed set of dash arrays, say `['0', '1', '2', '1 2', '1 1 2']`, with each color associated with one.