### PR TITLE
Add label to comment textarea

### DIFF
--- a/server/main/static/main/common.css
+++ b/server/main/static/main/common.css
@@ -1081,6 +1081,17 @@ input[type="checkbox"].form-control {
     margin: 0;
     width: 100%;
 }
+form.comments {
+    margin-left: 1em;
+}
+form.comments label {
+    display: block;
+    margin-bottom: 0.5em;
+    font-weight: bold;
+}
+form.comments button {
+    margin-top: 1em;
+}
 form.comments textarea {
     width: 50%;
 }

--- a/server/templates/main/study-overview.html
+++ b/server/templates/main/study-overview.html
@@ -273,17 +273,13 @@
     <div class="sectionActions">
       <form method="POST" class="comments edd-form">
         {% csrf_token %}
-        {{ new_comment.as_p }}
-        <p>
-          <button
-            class="btn btn-primary"
-            name="action"
-            type="submit"
-            value="comment"
-          >
+        <div class="form-group">
+          <label for="id_body">New Comment</label>
+          <textarea name="body" cols="40" rows="10" required="" id="id_body" class="form-control"></textarea>
+          <button class="btn btn-primary mt-3" name="action" type="submit" value="comment">
             {% translate 'Add Comment' %}
           </button>
-        </p>
+        </div>
       </form>
     </div>
   </div>


### PR DESCRIPTION
This adds a label to the comment textarea to provide context so that users know the purpose of the textarea. There was no label on the page previously. [WCAG 1.3.5](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html)

<img width="552" alt="Screen Shot 2022-06-13 at 3 43 28 PM" src="https://user-images.githubusercontent.com/3331/173442155-08814a10-1f4e-4063-98bd-ff3fbb74c4bd.png">

This addressed issue #76.